### PR TITLE
Added Support for EnvironmentZ

### DIFF
--- a/src/main/resources/data/environmentz/tags/items/warm_armor.json
+++ b/src/main/resources/data/environmentz/tags/items/warm_armor.json
@@ -1,0 +1,9 @@
+{
+    "replace": false,
+    "values": [
+        "betternether:nether_ruby_helmet",
+        "betternether:nether_ruby_chestplate",
+        "betternether:nether_ruby_leggings",
+        "betternether:nether_ruby_boots"
+    ]
+}

--- a/src/main/resources/data/environmentz/tags/items/warm_armor.json
+++ b/src/main/resources/data/environmentz/tags/items/warm_armor.json
@@ -4,6 +4,10 @@
         "betternether:nether_ruby_helmet",
         "betternether:nether_ruby_chestplate",
         "betternether:nether_ruby_leggings",
-        "betternether:nether_ruby_boots"
+        "betternether:nether_ruby_boots",
+        "betternether:cincinnasite_helmet",
+        "betternether:cincinnasite_helmet_chestplate",
+        "betternether:cincinnasite_helmet_leggings",
+        "betternether:cincinnasite_helmet_boots"
     ]
 }


### PR DESCRIPTION
Since Better Nether is such a massive part of Medieval Minecraft and is being used with EnvironmentZ a lot, now, I wanted to add support for the Ruby and/or Cincinnasite Armours. If this isn't appropriate, I completely understand. Thanks for taking this PR under consideration.

EnvironmentZ is a mod that adds temperature into Minecraft, so players can get cold and warm as well as freeze and overheat. As such, since the Ruby and Cincinnasite Armours have their origins in the Nether, it made sense to me that they might provide some protection from the cold.

I did each set as a separate commit so that if one shouldn't be accepted that it can just be ignored.

Have a wonderful day and thank you for an amazing mod!