### PR TITLE
Fixed helmet

### DIFF
--- a/src/main/resources/data/environmentz/tags/items/warm_armor.json
+++ b/src/main/resources/data/environmentz/tags/items/warm_armor.json
@@ -6,8 +6,8 @@
         "betternether:nether_ruby_leggings",
         "betternether:nether_ruby_boots",
         "betternether:cincinnasite_helmet",
-        "betternether:cincinnasite_helmet_chestplate",
-        "betternether:cincinnasite_helmet_leggings",
-        "betternether:cincinnasite_helmet_boots"
+        "betternether:cincinnasite_chestplate",
+        "betternether:cincinnasite_leggings",
+        "betternether:cincinnasite_boots"
     ]
 }


### PR DESCRIPTION
Responsible for error on client side

`[17:33:42] [Render thread/ERROR]: Couldn't load tag environmentz:warm_armor as it is missing following references: betternether:cincinnasite_helmet_chestplate (from Better Nether), betternether:cincinnasite_helmet_leggings (from Better Nether), betternether:cincinnasite_helmet_boots (from Better Nether)`

Which caused server side issue

`[00:45:21] [Server thread/INFO]: last_resort1 lost connection: Internal Exception: io.netty.handler.codec.DecoderException: java.lang.IndexOutOfBoundsException: index: 3, length: 3610 (expected: range(0, 256))`