### PR TITLE
Update en_us.json

### DIFF
--- a/src/main/resources/assets/betternether/lang/en_us.json
+++ b/src/main/resources/assets/betternether/lang/en_us.json
@@ -39,6 +39,7 @@
   "advancements.betternether.ruby_ore.title": "Ruby Ore",
   "advancements.betternether.ruby_tools.description": "Obtain some ruby tools from the depth of the Nether",
   "advancements.betternether.ruby_tools.title": "Red Nether",
+  "attribute.name.player.bn_obsidian_block_break_speed": "Obsidian Break Speed"
   "betternether.flat_nether": "Flat Nether",
   "betternether.survive.nethergound": "Nether Ground",
   "biome.betternether.bone_reef": "Bone Reef",


### PR DESCRIPTION
This adds the missing 'attribute.name.player.bn_obsidian_block_break_speed' to the lang file, fixing this issue with the Cincinnasite-Diamond pickaxe.
![image](https://github.com/user-attachments/assets/6d198681-a3c6-44ae-ac86-f2b221af986c)

I have repeated this fix across the 1.20 and 1.20.3 branches, but do not wish to spam pull requests.