### PR TITLE
Fix shears have no tool component bug

### DIFF
--- a/src/main/java/org/betterx/betternether/items/complex/NetherSet.java
+++ b/src/main/java/org/betterx/betternether/items/complex/NetherSet.java
@@ -1,5 +1,7 @@
 package org.betterx.betternether.items.complex;
 
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.ShearsItem;
 import org.betterx.bclib.api.v2.advancement.AdvancementManager;
 import org.betterx.bclib.items.tool.BaseShearsItem;
 import org.betterx.betternether.BetterNether;
@@ -59,7 +61,7 @@ public class NetherSet extends EquipmentSet {
 
 
             if (withShears) {
-                add(ToolSlot.SHEARS_SLOT, (t, p) -> new BaseShearsItem(p), shearPropertiesBuilder);
+                add(ToolSlot.SHEARS_SLOT, (t, p) -> new BaseShearsItem(p.component(DataComponents.TOOL, ShearsItem.createToolProperties())), shearPropertiesBuilder);
             }
         }
 


### PR DESCRIPTION
Add the tool component data to shears.
I think this is a bug that must be fixed.

Before this change done, cincinnasite shears cannot instantly break leaves block.
But now it can be used to mine leaves block as quickly as iron shears now.